### PR TITLE
修复 san-router 无法在 IE8 下运行的问题

### DIFF
--- a/src/component/link.js
+++ b/src/component/link.js
@@ -20,7 +20,12 @@ export default {
             router.locator.redirect(href.replace(/^#/, ''));
         }
 
-        e.preventDefault();
+        if (e.preventDefault) {
+            e.preventDefault();
+        }
+        else {
+            e.returnValue = false;
+        }
     },
 
     computed: {

--- a/src/locator/hash.js
+++ b/src/locator/hash.js
@@ -51,14 +51,26 @@ export default class Locator extends EventTarget {
      * 开始监听 url 变化
      */
     start() {
-        window.addEventListener('hashchange', this[HASHCHANGE_HANDLER_KEY], false);
+        if (window.addEventListener) {
+            window.addEventListener('hashchange', this[HASHCHANGE_HANDLER_KEY], false);
+        }
+
+        if (window.attachEvent) {
+            window.attachEvent('onhashchange', this[HASHCHANGE_HANDLER_KEY]);
+        }
     }
 
     /**
      * 停止监听
      */
     stop() {
-        window.removeEventListener('hashchange', this[HASHCHANGE_HANDLER_KEY], false);
+        if (window.removeEventListener) {
+            window.removeEventListener('hashchange', this[HASHCHANGE_HANDLER_KEY], false);
+        }
+
+        if (window.detachEvent) {
+            window.detachEvent('onhashchange', this[HASHCHANGE_HANDLER_KEY]);
+        }
     }
 
     /**


### PR DESCRIPTION
主要修复：

1.  IE8下对 preventDefault 的兼容性处理
2. IE8下对 addEventListener 的兼容性处理