### PR TITLE
修复二次开发中遇到的个别问题

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
     "presets": [
-        ["es2015", {"modules": false, "loose": true}],
+        ["es2015", {"loose": true}],
         ["es2016"]
     ],
     "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,11 @@
 {
     "presets": [
-        "es2015",
-        "es2016",
-        "es2015-loose"
+        ["es2015", {"modules": false, "loose": true}],
+        ["es2016"]
     ],
     "plugins": [
-        'transform-es3-member-expression-literals',
-        'transform-es3-property-literals'
+        "transform-es3-member-expression-literals",
+        "transform-es3-property-literals"
     ]
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "rm -rf dist && webpack && uglifyjs dist/san-router.source.js -mco dist/san-router.js",
     "dev": "webpack-dev-server --config test/webpack.config.js --history-api-fallback --host 0.0.0.0 --port 8384",
-    "test": "npm run dev && open http://0.0.0.0:8384/test/"
+    "test": "npm run dev && open http://0.0.0.0:8384/test/",
+    "lint": "fecs ./src"
   },
   "devDependencies": {
     "babel-core": "^6.21.0",
@@ -13,8 +14,9 @@
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-preset-es2015": "^6.18.0",
-    "babel-preset-es2015-loose": "^8.0.0",
     "babel-preset-es2016": "^6.16.0",
+    "eslint-plugin-babel": "^4.1.2",
+    "fecs": "^1.4.1",
     "glob": "^7.1.1",
     "san": "^3.0.3-rc.8",
     "uglify-js": "^2.7.5",

--- a/src/component/link.js
+++ b/src/component/link.js
@@ -11,7 +11,15 @@ import {router} from '../main';
 import resolveURL from '../resolve-url';
 
 export default {
-    template: '<a href="{{href}}" onclick="return false;" on-click="clicker($event)" target="{{target}}" class="{{class}}" style="{{style}}"><slot></slot></a>',
+    template: `<a href="{{href}}"
+        onclick="return false;"
+        on-click="clicker($event)"
+        target="{{target}}"
+        class="{{class}}"
+        style="{{style}}"
+        >
+        <slot></slot>
+    </a>`,
 
     clicker(e) {
         let href = this.data.get('href');
@@ -29,7 +37,7 @@ export default {
     },
 
     computed: {
-        href: function () {
+        href() {
             let url = this.data.get('to');
             if (typeof url !== 'string') {
                 return;
@@ -43,4 +51,4 @@ export default {
             return href;
         }
     }
-}
+};

--- a/src/locator/hash.js
+++ b/src/locator/hash.js
@@ -32,6 +32,7 @@ function getLocation() {
  * @class
  */
 export default class Locator extends EventTarget {
+
     /**
      * 构造函数
      */

--- a/src/locator/html5.js
+++ b/src/locator/html5.js
@@ -25,6 +25,7 @@ function getLocation() {
  * @class
  */
 export default class Locator extends EventTarget {
+
     /**
      * 构造函数
      */

--- a/src/main.js
+++ b/src/main.js
@@ -225,7 +225,7 @@ export class Router {
      * @param {Function?} config.handler 路由函数
      * @param {Function?} config.Component 路由组件
      * @param {string} config.target 路由组件要渲染到的目标位置
-     * @return {Function} san-router 实例
+     * @return {Object} san-router 实例
      */
     add(config) {
         let {rule, handler, target = '#main', Component} = config;
@@ -257,7 +257,7 @@ export class Router {
     /**
      * 启动路由功能
      *
-     * @return {Function} san-router 实例
+     * @return {Object} san-router 实例
      */
     start() {
         if (!this.isStarted) {
@@ -273,7 +273,7 @@ export class Router {
     /**
      * 停止路由功能
      *
-     * @return {Function} san-router 实例
+     * @return {Object} san-router 实例
      */
     stop() {
         this.locator.un('redirect', this.locatorRedirectHandler);
@@ -287,7 +287,7 @@ export class Router {
      * 设置路由模式
      *
      * @param {string} mode 路由模式，hash | html5
-     * @return {Function} san-router 实例
+     * @return {Object} san-router 实例
      */
     setMode(mode) {
         mode = mode.toLowerCase();

--- a/src/main.js
+++ b/src/main.js
@@ -150,7 +150,7 @@ export class Router {
     /**
      * 添加路由监听器
      *
-     * @param {function({Object})} listener 监听器
+     * @param {function(e, config)} listener 监听器
      */
     listen(listener) {
         this.listeners.push(listener);

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@
 import HashLocator from './locator/hash';
 import HTML5Locator from './locator/html5';
 import parseURL from './parse-url';
-import Link from './component/link'
+import Link from './component/link';
 
 let routeID = 0x5942b;
 let guid = () => (++routeID).toString();
@@ -27,6 +27,7 @@ export let version = '1.1.1';
  * @class
  */
 export class Router {
+
     /**
      * 构造函数
      *
@@ -120,7 +121,7 @@ export class Router {
                 state = 1;
                 i++;
                 doNext();
-            };
+            }
 
             /**
              * 运行路由行为
@@ -149,7 +150,7 @@ export class Router {
     /**
      * 添加路由监听器
      *
-     * @param {function({Object}e, {Object}config)} listener 监听器
+     * @param {function({Object})} listener 监听器
      */
     listen(listener) {
         this.listeners.push(listener);
@@ -224,6 +225,7 @@ export class Router {
      * @param {Function?} config.handler 路由函数
      * @param {Function?} config.Component 路由组件
      * @param {string} config.target 路由组件要渲染到的目标位置
+     * @return {Function} san-router 实例
      */
     add(config) {
         let {rule, handler, target = '#main', Component} = config;
@@ -254,6 +256,8 @@ export class Router {
 
     /**
      * 启动路由功能
+     *
+     * @return {Function} san-router 实例
      */
     start() {
         if (!this.isStarted) {
@@ -268,6 +272,8 @@ export class Router {
 
     /**
      * 停止路由功能
+     *
+     * @return {Function} san-router 实例
      */
     stop() {
         this.locator.un('redirect', this.locatorRedirectHandler);
@@ -281,6 +287,7 @@ export class Router {
      * 设置路由模式
      *
      * @param {string} mode 路由模式，hash | html5
+     * @return {Function} san-router 实例
      */
     setMode(mode) {
         mode = mode.toLowerCase();

--- a/src/parse-url.js
+++ b/src/parse-url.js
@@ -14,24 +14,26 @@
  * @return {Object}
  */
 export default function parseURL(url) {
-    let result = {};
+    const result = {
+        hash: '',
+        queryString: '',
+        query: {},
+        path: url
+    };
 
     // parse hash
-    result.hash = '';
-    let hashStart = url.indexOf('#');
+    const hashStart = result.path.indexOf('#');
     if (hashStart >= 0) {
-        result.hash = url.slice(hashStart + 1);
-        url = url.slice(0, hashStart);
+        result.hash = result.path.slice(hashStart + 1);
+        result.path = result.path.slice(0, hashStart);
     }
 
     // parse query
-    result.queryString = '';
-    let query = {};
-    result.query = query;
-    let queryStart = url.indexOf('?');
+    const query = result.query;
+    const queryStart = result.path.indexOf('?');
     if (queryStart >= 0) {
-        result.queryString = url.slice(queryStart + 1);
-        url = url.slice(0, queryStart);
+        result.queryString = result.path.slice(queryStart + 1);
+        result.path = result.path.slice(0, queryStart);
 
         result.queryString.split('&').forEach(querySeg => {
             // 考虑到有可能因为未处理转义问题，
@@ -48,7 +50,9 @@ export default function parseURL(url) {
 
             // 已经存在这个参数，且新的值不为空时，把原来的值变成数组
             if (query.hasOwnProperty(key)) {
+                /* eslint-disable */
                 query[key] = [].concat(query[key], value);
+                /* eslint-disable */
             }
             else {
                 query[key] = value;
@@ -56,9 +60,6 @@ export default function parseURL(url) {
         });
 
     }
-
-    // left path
-    result.path = url;
 
     return result;
 }

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,7 @@
     <script src="lib/jasmine-2.4.0/jasmine-html.js"></script>
     <script src="lib/jasmine-2.4.0/console.js"></script>
     <script src="lib/jasmine-2.4.0/boot.js"></script>
-    <script src="../node_modules/san/dist/san.source.js"></script>
+    <script src="../node_modules/san/dist/san.dev.js"></script>
 
     <script src="index.js"></script>
 

--- a/test/index.js
+++ b/test/index.js
@@ -72,7 +72,7 @@ describe('Synthesis', () => {
         }
     });
 
-    it('hash mode, link to route', done => {
+    it('html5 mode, link to route', done => {
         router.setMode('html5');
 
         let routeTimes = 0;


### PR DESCRIPTION
1. 删除过时的 babel-preset-es2015-loose 依赖，使用 babel-preset-es2015 的参数 loose 替代，避免在开发环境中抛出无法处理 babel-runtime 模块的问题。
2. 统一 babelrc 中的引号为双引号
3. 加入 fecs
4. 修正源码中的风格问题
5. 修正一个测试用例的名称