### PR TITLE
hash情况下，如果仅有'#'，也应该设置成默认路由

### DIFF
--- a/src/locator/hash.js
+++ b/src/locator/hash.js
@@ -20,7 +20,7 @@ function getLocation() {
     // 在Firefox下获取会成为**abc=def**
     // 为了避免这一情况，需要从`location.href`中分解
     let index = location.href.indexOf('#');
-    let url = index < 0 ? '/' : location.href.slice(index + 1);
+    let url = index < 0 ? '/' : (location.href.slice(index + 1) || '/');
 
     return url;
 }


### PR DESCRIPTION
hash下，仅有 '#' 情况下，默认的路由也应该是 '/'，这样可以保证 无论是 hash 或者 html5的行为一致、无缝切换