### PR TITLE
让添加路由方法的 target 属性支持 HTML Element 类型

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -201,7 +201,8 @@ export class Router {
                 component.data.set('route', e);
                 component._callHook('route');
 
-                let targetEl = document.querySelector(routeItem.target);
+                let target = routeItem.target;
+                let targetEl = target instanceof Element ? target : document.querySelector(target);
 
                 if (!targetEl) {
                     throw new Error('[SAN-ROUTER ERROR] '


### PR DESCRIPTION
偶尔会遇到类似下面的用法，用 `querySeletor` 可能不太适合：

```js
const $root = document.createElement('div')
document.appendChild($root)
router.add({
  target: $root
})
```