### PR TITLE
兼容ie6-ie7

### DIFF
--- a/src/elementSelector.js
+++ b/src/elementSelector.js
@@ -1,0 +1,21 @@
+/*
+*
+* @file 选择器
+* @author vincent lau/413893093@qq.com
+*/
+
+/**
+ * 元素选择器
+ *
+ * @param selector 选择器
+ * @returns {*} 返回元素或者undefined
+ */
+export default function (selector) {
+    let el;
+    if (document.querySelector) {
+        el = document.querySelector(selector);
+    } else {
+        el = document.getElementById(selector.replace(/#/i, ''));
+    }
+    return el;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import HashLocator from './locator/hash';
 import HTML5Locator from './locator/html5';
 import parseURL from './parse-url';
 import Link from './component/link';
+import elementSelector from './elementSelector'
 
 let routeID = 0x5942b;
 let guid = () => (++routeID).toString();
@@ -202,7 +203,7 @@ export class Router {
                 component._callHook('route');
 
                 let target = routeItem.target;
-                let targetEl = target instanceof Element ? target : document.querySelector(target);
+                let targetEl = target instanceof Element ? target : elementSelector(target);
 
                 if (!targetEl) {
                     throw new Error('[SAN-ROUTER ERROR] '


### PR DESCRIPTION
应该增加一个选择器，兼容ie6-ie7，与san保持一致，起码保证target默认值的时候在ie7-6的时候不会报错。
只支持id选择器，毕竟支持了html Element类型。